### PR TITLE
Fix CSS for image URL

### DIFF
--- a/vendor/assets/stylesheets/hopscotch.css
+++ b/vendor/assets/stylesheets/hopscotch.css
@@ -402,7 +402,7 @@ div.hopscotch-bubble.no-number .hopscotch-bubble-content {
 div.hopscotch-bubble .hopscotch-bubble-close {
     color: #000;
     background: transparent -192px -92px no-repeat;
-    background-image: image-url('sprite-green.png');
+    background-image: url('sprite-green.png');
     display: block;
     padding: 8px;
     position: absolute;
@@ -419,7 +419,7 @@ div.hopscotch-bubble .hopscotch-bubble-close.hide-all {
 }
 div.hopscotch-bubble .hopscotch-bubble-number {
     background: transparent 0 0 no-repeat;
-    background-image: image-url('sprite-green.png');
+    background-image: url('sprite-green.png');
     color: #fff;
     display: block;
     float: left;


### PR DESCRIPTION
background-image: image-url('sprite-green.png') is invalid CSS. Updated now with valid CSS.
